### PR TITLE
Implementing slow tests

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -2,6 +2,8 @@ from astropy.tests.pytest_plugins import *
 
 
 def pytest_addoption(parser):
+    parser.addoption("--slow", action="store_true", help="run slow tests")
+
     parser.addoption("--remote-data", action="store_true",
                      help="run tests with online data")
     parser.addoption("--open-files", action="store_true",

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -17,7 +17,10 @@ from tardis.plasma.standard_plasmas import LegacyPlasmaArray
 
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'tests', 'data', fname)
-@pytest.mark.slow
+
+slow = pytest.mark.skipif( not pytest.config.getoption('--slow') , reason= "needs --slow to run this")
+
+@slow
 @pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
                     reason='--atomic_database was not specified')
 class TestSimpleRun():

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -17,14 +17,13 @@ from tardis.plasma.standard_plasmas import LegacyPlasmaArray
 
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'tests', 'data', fname)
-
+@pytest.mark.slow
 @pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
                     reason='--atomic_database was not specified')
 class TestSimpleRun():
     """
     Very simple run
     """
-
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self):


### PR DESCRIPTION
This PR implements running slow test (test_tardis_full.py), only when a command line option '--slow' is specified. Example of a command that runs slow tests: 'py.test --slow -q --atomic-dataset=< your path>'

Changes made to:
- conftest.py (added a parser option to recognize --slow)
- test_tardis_full.py (added pytest 'skipif' decorator, which skips the tests if --slow is not specified)

This is a prelim task for testing module. @Orbitfold
